### PR TITLE
use thingatpt over smartparens

### DIFF
--- a/ajsc.el
+++ b/ajsc.el
@@ -102,7 +102,7 @@
 ;;;; Requirements
 
 (require 'comint)
-(require 'smartparens)
+(require 'thingatpt)
 (require 'subr-x)
 
 ;;;; The Rest
@@ -350,11 +350,10 @@ be sending anything remotely close to the limit."
 (defun ajsc-send-expression-at-point ()
   "Send expression at point."
   (interactive)
-  (let* ((thing (sp-get-thing t))
-         (start (sp-get thing :beg))
-         (end (sp-get thing :end)))
-    (when (and start end)
-      (ajsc-send-region start end))))
+  (when-let* ((bound (bounds-of-thing-at-point 'sexp))
+              (start (car bound))
+              (end (cdr bound)))
+    (ajsc-send-region start end)))
 
 (defun ajsc-switch-to-repl ()
   "Switch to the repl buffer named by `ajsc-repl-buffer-name`."


### PR DESCRIPTION
What do you think about this change, use `thingatpt` (or thing-at-point) over `smart-parens`. The difference is simply one is built in and the other extra dependency. Functionality-wise, two should offer similar capabilities.

There are a few comments about smartparens which should be adjusted accordingly if you are happy with this change.