### PR TITLE
Inital bindat integration

### DIFF
--- a/ajsc.el
+++ b/ajsc.el
@@ -392,7 +392,7 @@ be sending anything remotely close to the limit."
           (let* ((string* (substring-no-properties string))
                  (msg (ajsc-pack-string string*)))
             (message "sending: %S" msg)
-            (process-send-string process msg)
+            (process-send-string proc msg)
             ;; (comint-simple-send proc msg)
             )))
   (setq mode-line-process '(":%s")))
@@ -472,7 +472,7 @@ endpoint.  ENDPOINT is a string of the form: \"hostname:port\"."
               ;; XXX: without this, header bytes were being interpreted as
               ;;      multibyte sometimes
               (set-process-coding-system repl-process 'binary)
-              (process-send-string process (ajsc-pack-string endpoint))
+              (process-send-string repl-process (ajsc-pack-string endpoint))
               (with-current-buffer repl-buffer
                 (ajsc-mode)
                 (pop-to-buffer (current-buffer))

--- a/ajsc.el
+++ b/ajsc.el
@@ -137,6 +137,18 @@ Host and port should be delimited with ':'."
 [0] the result of evaluation.
 [1] the next repl prompt.")
 
+(defvar ajsc--pack-bindat-spec
+  (bindat-type
+    (length uintr 32)
+    (data str length)))
+
+(defun ajsc-pack-string (str)
+  "Pack string STR into binary data."
+  (bindat-pack
+   ajsc--pack-bindat-spec
+   `((length . ,(string-bytes str))
+     (data . ,str))))
+
 (defun ajsc-net-header-str (len)
   "Compute header string for Janet spork message of LEN bytes.
 
@@ -319,9 +331,7 @@ be sending anything remotely close to the limit."
 
 (defun ajsc-send-hello (process hello-str)
   "Send PROCESS the HELLO-STR."
-  (process-send-string process
-                       (concat (ajsc-net-header-str (string-bytes hello-str))
-                               hello-str)))
+  (process-send-string process (ajsc-pack-string hello-str)))
 
 ;;; commands
 
@@ -421,17 +431,17 @@ be sending anything remotely close to the limit."
   ;; remove header bytes appropriately
   (add-hook 'comint-preoutput-filter-functions
             #'ajsc-preoutput-filter-function
-           nil 'local)
+            nil 'local)
   ;; XXX: does this need to be restricted to apply only to certain buffers?
   ;; prepend header bytes
   (setq comint-input-sender
         (lambda (proc string)
-          (let ((msg (substring-no-properties
-                      (concat
-                       (ajsc-net-header-str (1+ (string-bytes string)))
-                       string))))
+          (let* ((string* (substring-no-properties string))
+                 (msg (ajsc-pack-string string*)))
             (message "sending: %S" msg)
-            (comint-simple-send proc msg))))
+            (process-send-string process msg)
+            ;; (comint-simple-send proc msg)
+            )))
   (setq mode-line-process '(":%s")))
 
 ;;;###autoload
@@ -509,7 +519,7 @@ endpoint.  ENDPOINT is a string of the form: \"hostname:port\"."
               ;; XXX: without this, header bytes were being interpreted as
               ;;      multibyte sometimes
               (set-process-coding-system repl-process 'binary)
-              (ajsc-send-hello repl-process endpoint)
+              (process-send-string process (ajsc-pack-string endpoint))
               (with-current-buffer repl-buffer
                 (ajsc-mode)
                 (pop-to-buffer (current-buffer))

--- a/ajsc.el
+++ b/ajsc.el
@@ -389,7 +389,10 @@ be sending anything remotely close to the limit."
   ;; prepend header bytes
   (setq comint-input-sender
         (lambda (proc string)
-          (let* ((string* (substring-no-properties string))
+          (let* ((string* (substring-no-properties
+                           (if (string-suffix-p "\n" string)
+                               string
+                               (concat string "\n"))))
                  (msg (ajsc-pack-string string*)))
             (message "sending: %S" msg)
             (process-send-string proc msg)


### PR DESCRIPTION
The incoming data the netrepl sends to its client (our emacs buffer here) receives a byte string similar to this format.

```
<header1><result of evaluation, warning, error message etc><header2><netrepl prompt string>
```

This should provide a good platform for tweaking it further.

Good thing is inital bindat integrations works, and it would reduce LoC.

Here is the bad things, this would only cover for  the protocol that goes through `branch 6. Otherwise`, to handle the other case which is `If (= (msg 0) 0xFF)` [1].

However, it no new features are to be introduced, this solution should suffice.

[1] [the netrepl protocol comments](https://github.com/janet-lang/spork/blob/df6623355cebfd3841084b965c690b251426637c/spork/netrepl.janet#L35-L56).



